### PR TITLE
Update Readme with instructions to run as a service with systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,52 @@ In Emby dashboard, you can create a webhook that points to your flask app:port/u
 
 ![image](https://user-images.githubusercontent.com/8314499/236054014-eec29591-7b93-4102-ad7c-956b58ee9660.png)
 
+### Step 7 - Run as a service Systemd
+
+Enter the following command into you terminal to replacing nano with your prefered text editor
+
+```bash
+sudo nano /etc/systemd/system/embyanisync.service
+```
+
+Paste the contents of the following into the new file
+replacing the `/opt/EmbyAniSync/` and `#USER#` with the correct ones for your install
+
+```bash
+[Unit]
+Description=EmbyAniSync
+After=multi-user.target
+[Service]
+Type=idle
+Restart=on-failure
+User=#USER#
+ExecStart=/bin/bash -c 'cd /opt/EmbyAniSync/ && python3 EmbyAniSync.py'
+[Install]
+WantedBy=multi-user.target
+```
+
+Then run the following commands to start the service and enable it at boot
+
+#### Reload the daemon for the latest files
+```bash
+sudo systemctl daemon-reload
+```
+
+#### Start the Service
+```bash
+sudo systemctl start embyanisync
+```
+
+#### Check the service is running
+```bash
+sudo systemctl status embyanisync
+```
+
+#### Enable at boot
+```bash
+sudo systemctl enable embyanisync
+```
+
 ## Optional features 
 
 All of this is copied over from the Parent Project so not 100% sure if accurate here.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ In Emby dashboard, you can create a webhook that points to your flask app:port/u
 
 ### Step 7 - Run as a service Systemd
 
-Enter the following command into you terminal to replacing nano with your prefered text editor
+Enter the following command into your terminal to create a new service file. 
+replacing nano with your preferred text editor
 
 ```bash
 sudo nano /etc/systemd/system/embyanisync.service


### PR DESCRIPTION
I have added instructions along with a systemd file to run this as a service enabled at boot on OS that use systemd, this would be beneficial for the many users that use headless machines for their servers