### PR TITLE
feat: push to ghcr

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -1,0 +1,51 @@
+﻿name: Docker Image
+concurrency: 
+  group: "docker-image"
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: emby-ani-sync
+  GHCR_REPO: ghcr.io/${{ github.repository }}
+
+on:
+  push:
+    branches:
+      - master
+
+jobs: 
+  build-image:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: "${{ env.GHCR_REPO }}"
+          tags: |
+            type=raw,value=latest
+            type=sha,format=short
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.ref == 'refs/heads/master' }}
+          network: host
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@ This has since gone through a large re-design to have a bit of it's own identity
 
 Note: This project is not dead, I just haven't really had any need to work on it, just seems to work.
 
+## Running with Docker
+
+Create a ``docker-compose.yaml`` file or copy it to Portainer / Dockge / ...
+```yaml
+services:
+  emby-ani-sync:
+    image: ghcr.io/bpwhelan/emby-ani-sync
+    container_name: emby-ani-sync
+    ports:
+      - 8081:8081 # change left side of ":" to avoid port conflicts
+    volumes:
+      - /mnt/your-host-path/emby-ani-sync/:/embyanisync
+```
+Start the compose if you created the file:
+```bash
+docker compose up -d
+```
+
 ## Setup
 
 ### Step 1 - Install Python


### PR DESCRIPTION
Adds a workflow to push a docker image to the GHCR: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry
It reuses the existing Dockerfile and I updated the README with some instructions.
Please let me know whether you are willing to accept this.